### PR TITLE
Add --for_seed, bbox logic for labeled frames eks_multiview, fix shape assertion in extract ood frames

### DIFF
--- a/lp3d_analysis/post_process.py
+++ b/lp3d_analysis/post_process.py
@@ -245,7 +245,11 @@ def get_original_structure(
                 continue
 
             print(f"Checking directory: {dir_path}")
-            csv_files = [f for f in os.listdir(dir_path) if f.endswith('.csv')]
+            csv_files = [
+                f
+                for f in os.listdir(dir_path)
+                if f.endswith(".csv") and not f.endswith("_uncropped.csv")
+            ]
             print(f"Found {len(csv_files)} CSV files in {dir_name}")
             original_structure[dir_name] = csv_files
         

--- a/lp3d_analysis/utils.py
+++ b/lp3d_analysis/utils.py
@@ -53,7 +53,7 @@ def extract_ood_frame_predictions(
                 snippet_df = pd.read_csv(snippet_file, header=[0,1,2], index_col=0)
 
                 # extract center frame 
-                assert snippet_df.shape[0] & 2 != 0 # ensure odd number of frames 
+                assert snippet_df.shape[0] % 2 != 0 # ensure odd number of frames
                 idx_frame = int(np.floor(snippet_df.shape[0] / 2))
                 
                 # create results with original image path as index 

--- a/pipelines/pipeline_simple.py
+++ b/pipelines/pipeline_simple.py
@@ -23,7 +23,7 @@ VALID_MODEL_TYPES = [
 ]
 
 
-def pipeline(config_file: str):
+def pipeline(config_file: str, for_seed: int | None = None) -> None:
 
     # -------------------------------------------
     # Setup
@@ -46,6 +46,8 @@ def pipeline(config_file: str):
         for model_type in cfg_pipe.train_networks.model_types:
             for n_hand_labels in cfg_pipe.train_networks.n_hand_labels:
                 for rng_seed in cfg_pipe.train_networks.ensemble_seeds:
+                    if for_seed is not None and for_seed != rng_seed:
+                        continue
                     print(
                         f'fitting {model_type} model (rng_seed={rng_seed}) with {n_hand_labels}' 
                         f'hand labels'
@@ -73,6 +75,10 @@ def pipeline(config_file: str):
                             overwrite=cfg_pipe.train_networks.overwrite,
                             video_dir='videos-for-each-labeled-frame',
                         )
+
+    # The rest of the pipeline only runs when you run without --for_seed.
+    if for_seed is not None:
+        return
 
     for mode, mode_config in cfg_pipe.post_processing_videos.items():
         for model_type in cfg_pipe.train_networks.model_types:
@@ -208,6 +214,11 @@ if __name__ == "__main__":
         help='absolute path to .yaml configuration file',
         type=str,
     )
+    parser.add_argument(
+        '--for_seed',
+        help='only run a specific seed (useful for distributing training on lightning jobs)',
+        type=int,
+    )
     args = parser.parse_args()
 
-    pipeline(args.config)
+    pipeline(args.config, args.for_seed)


### PR DESCRIPTION
# For_seed flag

--for_seed allows you to parallelize pipeline training.

On a multi-GPU machine, you can run these in parallel:

```
CUDA_VISIBLE_DEVICES=0 python pipelines/pipeline_simple.py --config configs/pipeline.yaml --for_seed 0
CUDA_VISIBLE_DEVICES=1 python pipelines/pipeline_simple.py --config configs/pipeline.yaml --for_seed 1
...
```


On single-GPU machines (using lightning jobs) you can run:

```
(job 0)
cd lp3d_analysis
python pipeline_simple.py --config configs/pipeline.yaml --for_seed 0

(job 1)
cd lp3d_analysis
python pipeline_simple.py --config configs/pipeline.yaml --for_seed 1
```


when `--for_seed` is present, it will stop after training and inference. to run post processing you remove --for_seed

# Bbox

Multiview EKS needs to run in the original coordinate space for cropped datasets.

If the dataset has bbox files, we do the following (for labeled frames only but similar logic will extend to videos):

1. Save uncropped predictions to <filename>_uncropped.csv in each seed's model directory. Uncrop = add bbox.
2. Run multiview EKS using the _uncropped prediction files
3. Save multiview EKS outputs to _uncropped prediction files
4. Re-map the _uncropped files back to regular files. (subtract bbox)


